### PR TITLE
Google now defaults streetViewControl to true

### DIFF
--- a/releases/3.0/src/GoogleMap.php
+++ b/releases/3.0/src/GoogleMap.php
@@ -1959,11 +1959,16 @@ class GoogleMapAPI {
 			}   
 			
 			if($this->street_view_controls){
-				$_script .= "
-					mapOptions".$_key.".streetViewControl= true;
+                		$_script .= "
+					mapOptions".$_key.".streetViewControl = true;
 	
 				";
-			}
+            		} else {
+                		$_script .= "
+					mapOptions".$_key.".streetViewControl = false;
+	
+				";
+            		}
 			
 			
 			// Add any map styles if they are present


### PR DESCRIPTION
Adding an else condition so it doesn't show up if you call disableStreetViewControls()

OLD with disableStreetViewControls() called:

![screen shot 2017-02-23 at 11 53 49 am](https://cloud.githubusercontent.com/assets/219403/23276505/65a901d0-f9bf-11e6-834b-3f149b663a03.png)

NEW with disableStreetViewControls() called:

![screen shot 2017-02-23 at 11 54 09 am](https://cloud.githubusercontent.com/assets/219403/23276513/6e915590-f9bf-11e6-8b3f-9ebfd84d92a1.png)
